### PR TITLE
Fix For Each loop key type in DataProcessing

### DIFF
--- a/DataProcessing.bas
+++ b/DataProcessing.bas
@@ -205,7 +205,7 @@ Public Sub CompareOutputAndOutputNE()
 
     Dim lastRow As Long, r As Long
 
-    Dim key As String, personName As String, dateValue As Variant
+    Dim key As Variant, personName As String, dateValue As Variant
 
     lastRow = wsOutput.Cells(wsOutput.Rows.Count, COL_DATE).End(xlUp).row
     For r = 2 To lastRow


### PR DESCRIPTION
## Summary
- update the For Each loop variable to be a Variant when iterating dictionary keys in DataProcessing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e932660bcc833382c8669c004be6ef