### PR TITLE
Fix separator array quoting in NormalizeForTimeOff

### DIFF
--- a/DataProcessing.bas
+++ b/DataProcessing.bas
@@ -347,7 +347,7 @@ Private Function NormalizeForTimeOff(ByVal taskName As String) As String
     normalized = Replace(normalized, vbTab, " ")
 
     Dim separators As Variant
-    separators = Array("/", "-", "_", "\", ".", ",", "(", ")", ":", ";", "&", "+", "|", "!", "?", "'", """"", "[", "]", "{", "}", _
+    separators = Array("/", "-", "_", "\", ".", ",", "(", ")", ":", ";", "&", "+", "|", "!", "?", "'", Chr$(34), "[", "]", "{", "}", _
                        ChrW$(8211), ChrW$(8212), ChrW$(8216), ChrW$(8217))
 
     Dim sep As Variant


### PR DESCRIPTION
## Summary
- replace the double-quote separator literal with Chr$(34) to avoid syntax errors when building the separator array for NormalizeForTimeOff

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e945fe55fc8333a440c585580de6e4