### PR TITLE
Fix task column index for Output vs OutputNE comparison

### DIFF
--- a/DataProcessing.bas
+++ b/DataProcessing.bas
@@ -164,7 +164,7 @@ Public Sub CompareOutputAndOutputNE()
     Const REPORT_SHEET_NAME As String = "Output vs OutputNE"
     Const COL_DATE As Long = 1
     Const COL_NAME As Long = 2
-    Const COL_TASK As Long = 4
+    Const COL_TASK As Long = 3
 
     Dim wb As Workbook
     Set wb = ThisWorkbook


### PR DESCRIPTION
## Summary
- correct the task column index used when scanning OutputNE entries in the comparison routine
- ensure sick time and vacation-only rows are recognized as time off so they are excluded from mismatch reporting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e947cfefa08333ac711cd09d8cb2f1